### PR TITLE
Removed getDisplayMenuItem

### DIFF
--- a/lib/pages/commonHeaderPage.js
+++ b/lib/pages/commonHeaderPage.js
@@ -89,10 +89,6 @@ var CommonHeaderPage = function () {
     return commonHeaderMenuItems;
   };
 
-  this.getDisplayMenuItem = function () {
-    return commonHeaderMenuItems.get(0);
-  };
-
   this.getSignInButton = function () {
     return signInButton;
   };


### PR DESCRIPTION
@alex-deaconu please review. I removed it as it is specific to the app. The apps can access the same through getCommonHeaderMenuItems().get(0). cheers