### PR TITLE
Moved signin code to google page so it can be reused

### DIFF
--- a/lib/pages/commonHeaderPage.js
+++ b/lib/pages/commonHeaderPage.js
@@ -1,12 +1,8 @@
-/*globals element, by, browser */
+/*globals element, by */
 'use strict';
 var GoogleAuthPage = require('./googleAuthPage.js');
-var helper = require('../common/helper.js');
 
 var CommonHeaderPage = function () {
-
-  var USERNAME = browser.params.login.user;
-  var PASSWORD = browser.params.login.pass;
 
   var googleAuthPage = new GoogleAuthPage();
   var commonHeader = element(by.tagName('common-header'));
@@ -18,67 +14,12 @@ var CommonHeaderPage = function () {
 
     signInButton.isDisplayed().then(function (state) {
       if (state) {
-        browser.ignoreSynchronization = true;
-        signInButton.click().then(function () {
-          googleAuthPage.getSigninCard().isDisplayed().then(function () {
-            helper.wait(googleAuthPage.getSigninCard(), "Google Sigin Card").then(function () {
-              helper.wait(googleAuthPage.getEmailField(), "Google Sigin Email Field").then(function () {
-                helper.wait(googleAuthPage.getNextButton(), "Google Sigin Next Button").then(function () {
-                  googleAuthPage.getEmailField().sendKeys(USERNAME);
-                  googleAuthPage.getNextButton().click().then(function () {
-                    _enterPasswordAndSignIn();
-                  });
-                }, function () {
-                  helper.wait(googleAuthPage.getSignInButton(), "Google Sigin Sign In Button").then(function () {
-                    googleAuthPage.getEmailField().sendKeys(USERNAME);
-                    _enterPasswordAndSignIn();
-                  });
-                });
 
-              });
-            });
-          }, function () {
-            helper.wait(googleAuthPage.getAccountchooserTitle(), "Google Account Chooser").then(function () {
-              helper.wait(googleAuthPage.getChooseAccountFirstButton(), "Google Account Chooser").then(function () {
-                googleAuthPage.getChooseAccountFirstButton().click().then(function () {
-                  _waitToGoBackToTheAPPAfterLogin();
-                });
-              });
-            });
-          });
+        signInButton.click().then(function () {
+          googleAuthPage.signin();
         });
       }
     });
-  };
-
-  var _enterPasswordAndSignIn = function () {
-
-    helper.wait(googleAuthPage.getPasswordField(), "Google Sigin Password Field").then(function () {
-      googleAuthPage.getPasswordField().sendKeys(PASSWORD);
-      googleAuthPage.getSignInButton().click().then(function () {
-        googleAuthPage.getThirdPartyInfo().isDisplayed().then(function () {
-          helper.wait(googleAuthPage.getThirdPartyInfo(), "Google Third Party Info").then(function () {
-            helper.wait(googleAuthPage.getSubmitApproveAccessButton(), "Google Approce Access Button").then(function () {
-              googleAuthPage.getSubmitApproveAccessButton().click().then(function () {
-                _waitToGoBackToTheAPPAfterLogin();
-              });
-            });
-          });
-        }, function () {
-          _waitToGoBackToTheAPPAfterLogin();
-        });
-      });
-    });
-  };
-
-  var _waitToGoBackToTheAPPAfterLogin = function () {
-    browser.ignoreSynchronization = false;
-    browser.wait(function () {
-      return element(by.css('.spinner-backdrop')).isDisplayed().then(function (result) {
-        return !result;
-      });
-    }, 20000);
-    helper.wait(commonHeader, "Common Header");
   };
 
   this.getCommonHeader = function () {

--- a/lib/pages/googleAuthPage.js
+++ b/lib/pages/googleAuthPage.js
@@ -1,5 +1,7 @@
-/*globals element, by */
+/*globals element, by, browser*/
 'use strict';
+var helper = require('../common/helper.js');
+
 var GoogleAuthPage = function () {
   var url = "https://accounts.google.com";
   var signinCard = element(by.css('.signin-card'));
@@ -11,6 +13,69 @@ var GoogleAuthPage = function () {
   var submitApproveAccessButton = element(by.id('submit_approve_access'));
   var accountchooserTitle = element(by.id('accountchooser-title'));
   var chooseAccountFirstButton = element(by.id('choose-account-0'));
+
+  var USERNAME = browser.params.login.user;
+  var PASSWORD = browser.params.login.pass;
+
+  this.signin = function () {
+    browser.ignoreSynchronization = true;
+
+    helper.wait(signinCard, "Google Sigin Card").then(function () {
+      helper.wait(emailField, "Google Sigin Email Field").then(function () {
+        helper.wait(nextButton, "Google Sigin Next Button").then(function () {
+          emailField.sendKeys(USERNAME);
+          nextButton.click().then(function () {
+            _enterPasswordAndSignIn();
+          });
+        }, function () {
+          helper.wait(signInButton, "Google Sigin Sign In Button").then(function () {
+            emailField.sendKeys(USERNAME);
+            _enterPasswordAndSignIn();
+          });
+        });
+
+      });
+    }, function () {
+      helper.wait(accountchooserTitle, "Google Account Chooser").then(function () {
+        helper.wait(chooseAccountFirstButton, "Google Account Chooser").then(function () {
+          chooseAccountFirstButton.click().then(function () {
+            _waitToGoBackToTheAPPAfterLogin();
+          });
+        });
+      });
+    });
+
+  };
+
+  var _enterPasswordAndSignIn = function () {
+
+    helper.wait(passwordField, "Google Sigin Password Field").then(function () {
+      passwordField.sendKeys(PASSWORD);
+      signInButton.click().then(function () {
+        thirdPartyInfo.isDisplayed().then(function () {
+          helper.wait(thirdPartyInfo, "Google Third Party Info").then(function () {
+            helper.wait(submitApproveAccessButton, "Google Approce Access Button").then(function () {
+              submitApproveAccessButton.click().then(function () {
+                _waitToGoBackToTheAPPAfterLogin();
+              });
+            });
+          });
+        }, function () {
+          _waitToGoBackToTheAPPAfterLogin();
+        });
+      });
+    });
+  };
+
+  var _waitToGoBackToTheAPPAfterLogin = function () {
+    browser.ignoreSynchronization = false;
+    browser.wait(function () {
+      return element(by.css('.spinner-backdrop')).isDisplayed().then(function (result) {
+        return !result;
+      });
+    }, 20000);
+    //helper.wait(commonHeader, "Common Header");
+  };
 
   this.getUrl = function () {
     return url;


### PR DESCRIPTION
even when the CH signin button is not clicked

This is for driving the google auth pages even when we don't go to it through CH.

@alex-deaconu please review. I have tested it with displays-app.