### PR TITLE
Added chai assert

### DIFF
--- a/lib/common-e2e.js
+++ b/lib/common-e2e.js
@@ -1,12 +1,13 @@
 (function (module) {
   "use strict";
-  var expect = require('./common/expect.js');
+  var chai = require('./common/chai.js');
   var helper = require('./common/helper.js');
   var commonHeaderPage = require('./pages/commonHeaderPage.js');
   var googleAuthPage = require('./pages/googleAuthPage.js');
 
   var factory = {
-    expect: expect,
+    expect: chai.expect,
+    assert: chai.assert,
     helper: helper,
     commonHeaderPage: commonHeaderPage,
     googleAuthPage: googleAuthPage

--- a/lib/common/chai.js
+++ b/lib/common/chai.js
@@ -4,5 +4,7 @@ var chaiAsPromised = require('chai-as-promised');
 
 chai.use(chaiAsPromised);
 var expect = chai.expect;
+var assert = chai.assert;
 
-module.exports = expect;
+exports.assert = assert;
+exports.expect = expect;

--- a/test/index.js
+++ b/test/index.js
@@ -8,6 +8,10 @@ describe('rv-common-e2e', function () {
     assert.isDefined(rvCommonE2E.expect);
   });
 
+  it('should have assert defined!', function () {
+    assert.isDefined(rvCommonE2E.assert);
+  });
+
   it('should have helper defined!', function () {
     assert.isDefined(rvCommonE2E.helper);
   });


### PR DESCRIPTION
@alex-deaconu I have changed it to also have the chai assert available for the e2e tests. It is intended for CH and we can use it when we refactor it. Please review.

I have tested with schedules app and it worked fine. cheers