### PR TITLE
Check if element isPresent first

### DIFF
--- a/lib/common/helper.js
+++ b/lib/common/helper.js
@@ -31,8 +31,14 @@ exports.wait = wait;
  */
 var waitDisappear = function (element, label) {
   return browser.wait(function () {
-    return element.isDisplayed().then(function (state) {
-      return !state;
+    return element.isPresent().then(function (state) {
+      if (state === true) {
+        return element.isDisplayed().then(function (state) {
+          return !state;
+        });
+      } else {
+        return true;
+      }
     });
   }, 10000, label + " did not disappear");
 };


### PR DESCRIPTION
This helps when waiting for a modal to disappear. The modal is removed from the DOM so `isPresent` throws an error.

@rodrigopavezi please review. Thanks.