### PR TITLE
Wait for an element to be removed form DOM

### DIFF
--- a/lib/common/helper.js
+++ b/lib/common/helper.js
@@ -46,6 +46,21 @@ var waitDisappear = function (element, label) {
 exports.waitDisappear = waitDisappear;
 
 /**
+ * Usage: waitRemoved(element, label)
+ * element : It will wait for this element to be removed from view
+ * label : just used for the error message
+ */
+var waitRemoved = function (element, label) {
+  return browser.wait(function () {
+    return element.isPresent().then(function (state) {
+      return !state;
+    });
+  }, 10000, label + " did not disappear");
+};
+
+exports.waitRemoved = waitRemoved;
+
+/**
  * Usage: waitForElementTextToChange(element, textToWaitFor)
  * element : It will wait for this element text to change
  * textToWaitFor : text to wait for


### PR DESCRIPTION
`waitDisappear` can cause errors if the element is removed from the DOM while the promise chain is executing.

Created a simple function that just checks if the element `isPresent`.

FYI, all this work is for modal dialogues that don't get hidden, but actually get removed from the DOM.

@rodrigopavezi @ezequielc please review. Thanks.

Thanks.