### PR TITLE
Add screen comparison function

### DIFF
--- a/lib/common/helper.js
+++ b/lib/common/helper.js
@@ -5,6 +5,9 @@
  * element : It will wait for this element to come into view
  * label : just used for the error message
  */
+const writeStream = require("fs").createWriteStream;
+const execSync = require("child_process").execSync;
+
 var wait = function (element, label, timeout) {
   return browser.wait(function () {
     return element.isPresent().then(function (state) {
@@ -133,9 +136,9 @@ exports.clickWhenClickable = clickWhenClickable;
 var takeScreenshot = function (fileName, timeout) {
   return browser.wait(function () {
     return new Promise((res)=>{
-      browser.takeScreenshot(fileName)
+      browser.takeScreenshot()
       .then((png)=>{
-        require("fs").createWriteStream(fileName || "shot.png")
+        writeStream(fileName || "shot.png")
         .end(png, "base64", ()=>res(true));
       });
     });
@@ -143,3 +146,27 @@ var takeScreenshot = function (fileName, timeout) {
 };
 
 exports.takeScreenshot = takeScreenshot;
+
+var waitForScreenImage = function (compareFile, timeout=9000) {
+  let shotPath = execSync("mktemp", {encoding: "utf8"}).replace("\n","");
+  let diffPath = execSync("mktemp", {encoding: "utf8"}).replace("\n","");
+
+  let compareCmd = `mogrify -resize 1920x1080! ${shotPath} && ` +
+                   `mogrify -resize 1920x1080! ${compareFile} && ` +
+                   `compare -metric MSE ${shotPath} ${compareFile} ${diffPath} ` +
+                   `|| true`;
+
+  return browser.wait(new Promise(compareScreens), timeout, "screenshot timeout");
+
+  function compareScreens(res) {
+    browser.takeScreenshot()
+    .then((png)=>{
+      writeStream(shotPath).end(png, "base64", ()=>{
+        if (parseInt(execSync(compareCmd), 10) < 100) {return res(true);}
+        setTimeout(()=>{compareScreens(res);}, 1000);
+      });
+    });
+  }
+};
+
+exports.waitForScreenImage = waitForScreenImage;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rv-common-e2e",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "A node module containing all the common code for e2e",
   "main": "index.js",
   "homepage": "https://github.com/Rise-Vision/rv-common-e2e",


### PR DESCRIPTION
@settinghead @alex-deaconu @fjvallarino  please review

This provides browser.wait on screenshot match.   
Uses ImageMagick mogrify and compare functions (which I've verified exist on circle-ci)

We'll have to tweak the command line flags so that we're not too lenient.  I'll tweak that with some manual runs on cci.

