### PR TITLE
Keep a file for every screenshot

### DIFF
--- a/lib/common/helper.js
+++ b/lib/common/helper.js
@@ -148,18 +148,16 @@ var takeScreenshot = function (fileName, timeout) {
 exports.takeScreenshot = takeScreenshot;
 
 var waitForScreenImage = function (compareFile, timeout=9000) {
-  let shotPath = execSync("mktemp").replace("\n","");
-  let diffPath = execSync("mktemp").replace("\n","");
-
-  let compareCmd = `compare -metric MSE ${shotPath} ${compareFile} ${diffPath} 2>&1` +
-                   `|| true`;
-
   return browser.wait(new Promise(compareScreens), timeout, "screenshot timeout");
 
   function compareScreens(res) {
     browser.takeScreenshot()
     .then((png)=>{
+      let shotPath = execSync("mktemp").replace("\n","");
+      let diffPath = execSync("mktemp").replace("\n","");
       writeStream(shotPath).end(png, "base64", ()=>{
+        let compareCmd = `compare -metric MSE ${shotPath} ${compareFile} ${diffPath} 2>&1` +
+                        `|| true`;
         let compareResult = execSync(compareCmd);
         console.log(compareResult);
         if (parseInt(compareResult, 10) < 200) {return res(true);}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rv-common-e2e",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "A node module containing all the common code for e2e",
   "main": "index.js",
   "homepage": "https://github.com/Rise-Vision/rv-common-e2e",


### PR DESCRIPTION
This makes it easier to see what was being captured.  Without this the
screenshots are being overwritten during each test as the presentation
cycles through its different states.

@fjvallarino please review - just a small improvement to help troubleshooting